### PR TITLE
Update yaml load call to work with newer libraries

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -35,7 +35,7 @@ def load_yaml_file(file_path):
     except:
         print('failed to load %s'%file_path)
         die()
-    return yaml.load(f.read())
+    return yaml.safe_load(f.read())
 
 
 class ServerComm:


### PR DESCRIPTION
load() is deprecated and this script won't work out of the box anymore.  This fixes it.  See https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation